### PR TITLE
Handle custom ApiTester class, fix config cache problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel-admin-ext/api-tester",
+    "name": "nastuzzi-samy/api-tester",
     "description": "Api tester for laravel",
     "type": "library",
     "keywords": ["laravel-admin", "api", "tester"],
@@ -9,6 +9,10 @@
         {
             "name": "z-song",
             "email": "zosong@126.com"
+        },
+        {
+            "name": "NastuzziSamy",
+            "email": "samy@nastuzzi.fr"
         }
     ],
     "require": {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -135,6 +135,9 @@
                         }
                     }
                 },
+                error: function (data) {
+                    toastr.error(data.responseJSON.message);
+                },
                 cache: false,
                 contentType: false,
                 processData: false

--- a/src/ApiTester.php
+++ b/src/ApiTester.php
@@ -75,7 +75,7 @@ class ApiTester extends Extension
 
         $symfonyRequest = SymfonyRequest::create(
             $uri, $method, $parameters,
-            [], $files, ['HTTP_ACCEPT' => 'application/json']
+            [], $files, $this->getHeaders()
         );
 
         $request = Request::createFromBase($symfonyRequest);
@@ -91,6 +91,12 @@ class ApiTester extends Extension
         return $response;
     }
 
+    protected function getHeaders() {
+         return [
+             'HTTP_ACCEPT' => 'application/json'
+         ];
+    }
+
     /**
      * Login a user by giving userid.
      *
@@ -99,14 +105,21 @@ class ApiTester extends Extension
     protected function loginUsing($userId)
     {
         $guard = static::config('guard', 'api');
-
-        if ($method = static::config('user_retriever')) {
-            $user = call_user_func($method, $userId);
-        } else {
-            $user = app('auth')->guard($guard)->getProvider()->retrieveById($userId);
-        }
+        $user = $this->getUser($guard, $userId);
 
         $this->app['auth']->guard($guard)->setUser($user);
+
+        return $user;
+    }
+
+    /**
+     * Get a user by giving userid.
+     *
+     * @param $userId
+     */
+    protected function getUser($guard, $userId)
+    {
+        return app('auth')->guard($guard)->getProvider()->retrieveById($userId);
     }
 
     /**

--- a/src/ApiTesterController.php
+++ b/src/ApiTesterController.php
@@ -46,7 +46,8 @@ class ApiTesterController extends Controller
             return $key !== '';
         }, ARRAY_FILTER_USE_KEY);
 
-        $tester = new ApiTester();
+        $class = config('admin.extensions.api-tester.class', ApiTest::class);
+        $tester = new $class();
 
         $response = $tester->call($method, $uri, $parameters, $user);
 

--- a/src/ApiTesterServiceProvider.php
+++ b/src/ApiTesterServiceProvider.php
@@ -17,6 +17,6 @@ class ApiTesterServiceProvider extends ServiceProvider
             );
         }
 
-        ApiTester::boot();
+        config('admin.extensions.api-tester.class', ApiTest::class)::boot();
     }
 }


### PR DESCRIPTION
It is not allowed to use `Closure` in cache files in **PHP**.

To work with that, we can instead specify the class name of the `ApiTester`