### PR TITLE
避免由 unicode 转码引起的阅读障碍，保障接口数据的原样输出

### DIFF
--- a/src/ApiTester.php
+++ b/src/ApiTester.php
@@ -121,7 +121,7 @@ class ApiTester extends Extension
         $jsoned = json_decode($content);
 
         if (json_last_error() == JSON_ERROR_NONE) {
-            $content = json_encode($jsoned, JSON_PRETTY_PRINT);
+            $content = json_encode($jsoned, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
         }
 
         $lang = 'json';
@@ -132,8 +132,8 @@ class ApiTester extends Extension
         }
 
         return [
-            'headers'    => json_encode($response->headers->all(), JSON_PRETTY_PRINT),
-            'cookies'    => json_encode($response->headers->getCookies(), JSON_PRETTY_PRINT),
+            'headers'    => json_encode($response->headers->all(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
+            'cookies'    => json_encode($response->headers->getCookies(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
             'content'    => $content,
             'language'   => $lang,
             'status'     => [


### PR DESCRIPTION
转码时不使用 unicode